### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk: 
+  - openjdk8
+  - openjdk11
+  - openjdk12
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/TinkoffCreditSystems/checkinx-utils.svg?branch=master)](https://travis-ci.com/TinkoffCreditSystems/checkinx-utils)
+
 # CheckInx Utils
 
 You can check your query execution plan really simple by using this utils. Your tests could be look like:


### PR DESCRIPTION
Depends on #20
I suggest run continious integration on https://travis-ci.com since their plan is to unify their .com and .org resources and leave .com only - https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/
Build in my fork - https://travis-ci.com/isopov/checkinx-utils/builds/114542240
I have added a badge in README that points to not yet existing https://travis-ci.com/dsemyriazhko/checkinx-utils